### PR TITLE
PHPUnitの表記修正

### DIFF
--- a/translation-ja/testing.md
+++ b/translation-ja/testing.md
@@ -107,7 +107,7 @@ php artisan test --testsuite=Feature --stop-on-failure
 <a name="running-tests-in-parallel"></a>
 ### テストを並列で実行
 
-LaravelとPhpUnitはデフォルトで、単一のプロセス内でテストを順番に実行します。しかし、複数のプロセス間で同時にテストを実行し、テスト時間を大幅に削減できます。これを利用開始するには、"dev"の依存パッケージとして`brianium/paratest` Composerパッケージを確実にインストールしてください。次に、`test` Artisanコマンドを実行するときに、`--parallel`オプションを指定します。
+LaravelとPHPUnitはデフォルトで、単一のプロセス内でテストを順番に実行します。しかし、複数のプロセス間で同時にテストを実行し、テスト時間を大幅に削減できます。これを利用開始するには、"dev"の依存パッケージとして`brianium/paratest` Composerパッケージを確実にインストールしてください。次に、`test` Artisanコマンドを実行するときに、`--parallel`オプションを指定します。
 
 ```shell
 composer require brianium/paratest --dev


### PR DESCRIPTION
いつも日本語ドキュメントにお世話になっています。

PHPUnitの表記が異なる箇所がありました。
ご確認をよろしくお願いいたします。