### PR TITLE
通知ページのコード例の誤りを修正する

### DIFF
--- a/translation-ja/notifications.md
+++ b/translation-ja/notifications.md
@@ -86,7 +86,7 @@ php artisan make:notification InvoicePaid
 
     class User extends Authenticatable
     {
-     * @return \Illuminate\Notifications\Message\SlackMessage
+        use Notifiable;
     }
 
 このトレイトが提供する`notify`メソッドは、通知インスタンスを引数に受けます。


### PR DESCRIPTION
いつも翻訳ドキュメントのお世話になっております。

[通知ページ](https://readouble.com/laravel/10.x/ja/notifications.html#using-the-notifiable-trait)のコード例に誤りがありましたので、
[公式ドキュメント](https://laravel.com/docs/10.x/notifications#using-the-notifiable-trait)のコードに差し替えました。